### PR TITLE
feat(capture): support for element capture

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -19,6 +19,11 @@ const yargs = require('yargs')
     type: 'string',
     describe: 'output to file instead of stdout'
   })
+  .option('selector', {
+    alias: '$',
+    type: 'string',
+    describe: 'selector of element to capture'
+  })
 const argv = yargs.argv
 
 ;(async () => {

--- a/index.js
+++ b/index.js
@@ -34,7 +34,6 @@ const snap = async (content, opts = {}) => {
     }
     if (opts.selector) {
       await page.waitFor(opts.selector, {timeout: 10 * 1000})
-    
       source = await page.$(opts.selector)
     } else {
       if (!opts.clip) {
@@ -42,20 +41,17 @@ const snap = async (content, opts = {}) => {
         opts.clip = {x: 0, y: 0, width: view.width, height: view.height}
       }
     }
-    
     let captureOptions = {
       fullPage: opts.fullPage,
       quality: opts.quality,
       type: opts.type,
       omitBackground: opts.transparency
     }
-
     if (opts.clip) {
       // If a null/undefind clip is specified when using element capture, the whole screen is
       // grabbed rather than just the element. Puppeteer bug?
       captureOptions.clip = opts.clip
     }
-      
     image = await source.screenshot(captureOptions)
   } finally {
     await page.close()


### PR DESCRIPTION
Added support for specifying a dom selector to screenshot a specific DOM element. 